### PR TITLE
fix: Reduce verbosity of Authentication Failures

### DIFF
--- a/flask_cognito.py
+++ b/flask_cognito.py
@@ -188,7 +188,7 @@ def _cognito_auth_required():
         # check if token is signed by userpool
         payload = _cog.decode_token(token=token)
     except CognitoJWTException as e:
-        log.info('Authentication Failure', exc_info=error)
+        log.info('Authentication Failure', exc_info=e)
         raise CognitoAuthError('Invalid Cognito Authentication Token', str(e)) from e
 
     _request_ctx_stack.top.cogauth_cognito_jwt = payload

--- a/flask_cognito.py
+++ b/flask_cognito.py
@@ -111,7 +111,7 @@ class CognitoAuth(object):
         return self.identity_callback(jwt_payload)
 
     def _cognito_auth_error_handler(self, error):
-        log.exception(error)
+        log.info('Authentication Failure', exc_info=error)
         return jsonify(OrderedDict([
             ('error', error.error),
             ('description', error.description),
@@ -188,7 +188,7 @@ def _cognito_auth_required():
         # check if token is signed by userpool
         payload = _cog.decode_token(token=token)
     except CognitoJWTException as e:
-        log.exception(e)
+        log.info('Authentication Failure', exc_info=error)
         raise CognitoAuthError('Invalid Cognito Authentication Token', str(e)) from e
 
     _request_ctx_stack.top.cogauth_cognito_jwt = payload


### PR DESCRIPTION
Reduce to an `info` level, as an authentication failure on the server side isn't
expected to be actioned.

Closes #13
