### PR TITLE
Make Header Prefix Optional

### DIFF
--- a/flask_cognito.py
+++ b/flask_cognito.py
@@ -94,6 +94,11 @@ class CognitoAuth(object):
 
         parts = auth_header_value.split()
 
+        if not auth_header_prefix:
+            if len(parts) > 1:
+                raise CognitoAuthError('Invalid Cognito JWT Header', 'Token contains spaces')
+            return auth_header_value
+
         if parts[0].lower() != auth_header_prefix.lower():
             raise CognitoAuthError('Invalid Cognito JWT header',
                                    f'Unsupported authorization type. Header prefix "{parts[0].lower()}" does not match "{auth_header_prefix.lower()}"')

--- a/test_flask_cognito.py
+++ b/test_flask_cognito.py
@@ -1,0 +1,93 @@
+import flask_cognito
+from unittest import TestCase
+from unittest.mock import Mock
+
+
+class objectview(object):
+    def __init__(self, d):
+        self.__dict__ = d
+
+class TestHeaderPrefix(TestCase):
+
+  def test_valid_header_prefix(self):
+    flask_cognito._cog = objectview({'jwt_header_name' :'Authorization',
+                          'jwt_header_prefix' : 'Bearer'})
+
+    get_mock = Mock(return_value='Bearer Test')
+    request_mock = objectview({'headers': objectview({'get': get_mock})})
+    
+    flask_cognito.request = request_mock
+
+
+    ca = flask_cognito.CognitoAuth()
+    result  = ca.get_token()
+    assert (result == 'Test')
+    
+  def test_incorrect_header_prefix(self):
+    flask_cognito._cog = objectview({'jwt_header_name' :'Authorization',
+                          'jwt_header_prefix' : 'Bearer'})
+
+    get_mock = Mock(return_value='Something Test')
+    request_mock = objectview({'headers': objectview({'get': get_mock})})
+    flask_cognito.request = request_mock
+    ca = flask_cognito.CognitoAuth()
+    self.assertRaises(flask_cognito.CognitoAuthError, ca.get_token)
+  
+    
+  def test_malformed_header(self):
+    flask_cognito._cog = objectview({'jwt_header_name' :'Authorization',
+                          'jwt_header_prefix' : 'Bearer'})
+
+    get_mock = Mock(return_value='Something To Fail')
+    request_mock = objectview({'headers': objectview({'get': get_mock})})
+    flask_cognito.request = request_mock
+    ca = flask_cognito.CognitoAuth()
+    self.assertRaises(flask_cognito.CognitoAuthError, ca.get_token)
+
+  def test_with_prefix_empty_string(self):
+    flask_cognito._cog = objectview({'jwt_header_name' :'Authorization',
+                          'jwt_header_prefix' : ''})
+
+    get_mock = Mock(return_value='Something')
+    request_mock = objectview({'headers': objectview({'get': get_mock})})
+    flask_cognito.request = request_mock
+    ca = flask_cognito.CognitoAuth()
+    result = ca.get_token()
+    self.assertEqual('Something',result)
+  
+  def test_with_prefix_none(self):
+    flask_cognito._cog = objectview({'jwt_header_name' :'Authorization',
+                          'jwt_header_prefix' : None})
+
+    get_mock = Mock(return_value='Something')
+    request_mock = objectview({'headers': objectview({'get': get_mock})})
+    flask_cognito.request = request_mock
+    ca = flask_cognito.CognitoAuth()
+    result = ca.get_token()
+    self.assertEqual('Something',result)
+
+  def test_without_prefix_malformed(self):
+    flask_cognito._cog = objectview({'jwt_header_name' :'Authorization',
+                          'jwt_header_prefix' : None})
+
+    get_mock = Mock(return_value='Something Else')
+    request_mock = objectview({'headers': objectview({'get': get_mock})})
+    flask_cognito.request = request_mock
+    ca = flask_cognito.CognitoAuth()
+    self.assertRaises(flask_cognito.CognitoAuthError, ca.get_token)
+
+  def test_without_prefix_missing(self):
+    flask_cognito._cog = objectview({'jwt_header_name' :'Authorization',
+                          'jwt_header_prefix' : None})
+
+    get_mock = Mock(return_value=None)
+    request_mock = objectview({'headers': objectview({'get': get_mock})})
+    flask_cognito.request = request_mock
+    ca = flask_cognito.CognitoAuth()
+    result = ca.get_token()
+    self.assertIsNone(result)
+
+
+    
+
+


### PR DESCRIPTION
This commit makes it possible to use an empty header prefix, it also adds some basic unit tests for this functionality.

