### PR TITLE
Fix group decorator name

### DIFF
--- a/flask_cognito.py
+++ b/flask_cognito.py
@@ -146,16 +146,6 @@ def cognito_auth_required(fn):
 
     return decorator
 
-
-def cognito_group_permissions(groups: list):
-    def decorator(function):
-        @wraps(function)
-        def wrapper(*args, **kwargs):
-            _cognito_check_groups(groups)
-            return function(*args, **kwargs)
-        return wrapper
-    return decorator
-
 def cognito_check_groups(groups: list):
     def decorator(function):
         def wrapper(*args, **kwargs):
@@ -166,6 +156,8 @@ def cognito_check_groups(groups: list):
 
     return decorator
 
+## This adds an alias to the above function to resolve issue #16    
+cognito_group_permissions = cognito_check_groups
 
 def _cognito_check_groups(groups: list):
     """

--- a/flask_cognito.py
+++ b/flask_cognito.py
@@ -147,6 +147,15 @@ def cognito_auth_required(fn):
     return decorator
 
 
+def cognito_group_permissions(groups: list):
+    def decorator(function):
+        @wraps(function)
+        def wrapper(*args, **kwargs):
+            _cognito_check_groups(groups)
+            return function(*args, **kwargs)
+        return wrapper
+    return decorator
+
 def cognito_check_groups(groups: list):
     def decorator(function):
         def wrapper(*args, **kwargs):
@@ -165,7 +174,7 @@ def _cognito_check_groups(groups: list):
         :raise an exception if there is no group
     """
 
-    if 'cognito:groups' not in current_cognito_jwt:
+    if 'cognito:groups' not in current_cognito_jwt or current_cognito_jwt['cognito:groups'] is None:
         raise CognitoAuthError('Not Authorized',
                             'User doesn\'t have access to this resource',
                             status_code=403)

--- a/test_flask_cognito.py
+++ b/test_flask_cognito.py
@@ -88,6 +88,37 @@ class TestHeaderPrefix(TestCase):
     self.assertIsNone(result)
 
 
-    
+  def test_group_permissions_decorator(self):
+    flask_cognito.current_cognito_jwt = {'cognito:groups': ['admin', 'other']}
+    @flask_cognito.cognito_group_permissions(['admin'])
+    def some_func():
+      return True
+    self.assertTrue(some_func())
 
+  def test_group_permissions_fail_if_not_in_group(self):
+    flask_cognito.current_cognito_jwt = {'cognito:groups': ['other']}
+    @flask_cognito.cognito_group_permissions(['admin'])
+    def some_func():
+      return True
+    self.assertRaises(flask_cognito.CognitoAuthError, some_func)
 
+  def test_group_permissions_fail_if_no_groups(self):
+    flask_cognito.current_cognito_jwt = {'cognito:groups': []}
+    @flask_cognito.cognito_group_permissions(['admin'])
+    def some_func():
+      return True
+    self.assertRaises(flask_cognito.CognitoAuthError, some_func)
+
+  def test_group_permissions_fail_if_groups_is_none(self):
+    flask_cognito.current_cognito_jwt = {'cognito:groups': None}
+    @flask_cognito.cognito_group_permissions(['admin'])
+    def some_func():
+      return True
+    self.assertRaises(flask_cognito.CognitoAuthError, some_func) 
+
+  def test_group_permissions_fail_if_no_group_attribute(self):
+    flask_cognito.current_cognito_jwt = {'cognito:name': 'Something'}
+    @flask_cognito.cognito_group_permissions(['admin'])
+    def some_func():
+      return True
+    self.assertRaises(flask_cognito.CognitoAuthError, some_func)


### PR DESCRIPTION
This PR resolves issue #16 and names the decorator to the same name used in the README whilst retaining the original name to avoid breaking changes.

Additional test have also been added. 