### PR TITLE
Ensure identity_callback is defined before checking to see if it is set

### DIFF
--- a/flask_cognito.py
+++ b/flask_cognito.py
@@ -39,10 +39,12 @@ class CognitoAuthError(Exception):
 
 
 class CognitoAuth(object):
-    def __init__(self, app=None):
+    identity_callback = None
+
+    def __init__(self, app=None, identity_handler=None):
         self.app = app
         if app is not None:
-            self.init_app(app)
+            self.init_app(app, identity_handler=identity_handler)
 
     def init_app(self, app, identity_handler=None):
         for k, v in CONFIG_DEFAULTS.items():

--- a/test_flask_cognito.py
+++ b/test_flask_cognito.py
@@ -122,3 +122,15 @@ class TestHeaderPrefix(TestCase):
     def some_func():
       return True
     self.assertRaises(flask_cognito.CognitoAuthError, some_func)
+
+  def test_identity_handler_late_init(self):
+    ca = flask_cognito.CognitoAuth()
+
+    # This throws an exception if self.identity_callback is not defined yet,
+    # particularly if the property is defined by init_app which may not have
+    # been called yet.
+    @ca.identity_handler
+    def handler(payload):
+      return None
+
+    self.assertEqual(ca.identity_callback, handler)


### PR DESCRIPTION
WIth the following basic app sample, the error `AttributeError: 'CognitoAuth' object has no attribute 'identity_callback'` is thrown when trying to register an identity handler:

```python
app = Flask()
ca = CognitoAuth()

ca.identity_handler
def handler(payload):
    return None
```

This PR ensures that the `identity_callback` property that is being checked exists when registering an identity handler, because it currently does not until `init_app` is called.