### PR TITLE
adding the option to set Cookie as a header name

### DIFF
--- a/flask_cognito.py
+++ b/flask_cognito.py
@@ -88,7 +88,10 @@ class CognitoAuth(object):
         auth_header_prefix = _cog.jwt_header_prefix
 
         # get token value from header
-        auth_header_value = request.headers.get(auth_header_name)
+        if auth_header_name == 'Cookie':
+            return request.cookies.get('session_token')
+        else:
+            auth_header_value = request.headers.get(auth_header_name)
 
         if not auth_header_value:
             # no auth header found


### PR DESCRIPTION
For apps that use "code" response type from the log in process and then "grant_type": "authorization_code" to get a session token that they usually saved as a cookie.